### PR TITLE
Fixed pause or menu after restart when esc key pressed

### DIFF
--- a/Service/screen_manager.py
+++ b/Service/screen_manager.py
@@ -43,6 +43,8 @@ class ScreenManager():
             self.set_state("pause")
         elif event.key == 27 and self.current_state == "about":
             self.set_state("menu")
+        elif event.key == 27 and self.current_state == "restart":
+            self.set_state("pause")
         self.current_screen.on_event(event)
 
     def __set_current_screen(self):


### PR DESCRIPTION
Fix for not being able to pause the game or view the menu screen after game restart i.e on "restart" state